### PR TITLE
Fix unboundlocalerror

### DIFF
--- a/i3expo/daemon.py
+++ b/i3expo/daemon.py
@@ -303,6 +303,7 @@ def show_ui(source):
 def input_loop(screen, source, tiles, columns):
     running = True
     use_mouse = True
+    active_frame = None
 
     selected_id = 0
     while running:
@@ -368,7 +369,7 @@ def input_loop(screen, source, tiles, columns):
             logging.debug("Keyboard selected: %s", active_frame)
 
 
-        if jump:
+        if active_frame is not None and jump:
             if active_frame in global_knowledge.keys():
                 logging.info('Switching to workspace %s', active_frame)
                 i3.command(f'workspace number {active_frame}')


### PR DESCRIPTION
Fixes the following error:
```
[INFO] 2021-01-28 22:29:59,593: Showing UI
[INFO] 2021-01-28 22:24:21,464: Received pygame.<Event(768-KeyDown {'unicode': '\r', 'key': 13, 'mod': 0, 'scancode': 40, 'window': None})>
[ERROR] 2021-01-28 22:29:59,650: Failed to show UI
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/i3expo/daemon.py", line 293, in show_ui
    input_loop(screen, source, tiles, geometry.grid.x)
  File "/usr/lib/python3.9/site-packages/i3expo/daemon.py", line 372, in input_loop
    if active_frame in global_knowledge.keys():
UnboundLocalError: local variable 'active_frame' referenced before assignment
[INFO] 2021-01-28 22:29:59,651: Closing UI
```

Edit: Added a small log of the event that crashed it. In my case, I was running i3expo straight from my shell and it looks like my return key was still being detected, so `jump = True` to try to jump to the workspace corresponding to the active frame, but no active frame was selected yet, so :boom: . 

Edit2: Ignore the mixed timestamps. The log one was from another run.