### PR TITLE
Hide temporary workspace when running detached

### DIFF
--- a/i3expo/daemon.py
+++ b/i3expo/daemon.py
@@ -178,6 +178,9 @@ def process_image(raw_img):
 
 def update_workspace(workspace):
     # logging.debug("Update workspace %s", workspace.num)
+    if workspace.name == 'i3expod-temporary-workspace':
+        return
+    
     if workspace.num not in global_knowledge.keys():
         global_knowledge[workspace.num] = {
             'name': None,


### PR DESCRIPTION
When running the daemon with the detached workspace option, it sometimes shows the temporary workspace, which is never useful IMO. This PR makes sure that we don't render it.